### PR TITLE
fix: Run pip tasks as `patroni_system_user`

### DIFF
--- a/tasks/install_patroni.yml
+++ b/tasks/install_patroni.yml
@@ -24,6 +24,7 @@
         virtualenv_command: python{{ _patroni_python_version }} -m venv
       when: not ansible_check_mode
       environment: "{{ _patroni_general_proxy_env }}"
+      become_user: "{{ patroni_system_user }}"
 
     # Errors while installing this dependency on redhat system. Used the link below to provide a solution
     # https://bobcares.com/blog/error-pg_config-executable-not-found/
@@ -34,6 +35,7 @@
         virtualenv: "{{ patroni_venv_install_dir }}"
         extra_args: "--only-binary :{{ _patroni_psycopg_pip_package }}:"
       environment: "{{ _patroni_general_proxy_env }}"
+      become_user: "{{ patroni_system_user }}"
 
 - name: Install patroni from system packages
   when: not patroni_install_from_pip


### PR DESCRIPTION
## Description
Fix permission issue where virtualenv was created as root instead of postgres user. Added `become_user` to pip tasks to ensure virtualenv and packages are installed with correct ownership.

## Motivation and Context
My playbook failed when running on a hardened server (umask 077)

## How Has This Been Tested?
I deleted `/opt/patroni` and reran the playbook: it worked.

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
