### PR TITLE
fix: Fix pg_hba template to not output 'None' values

### DIFF
--- a/templates/etc/patroni/config.yml.j2
+++ b/templates/etc/patroni/config.yml.j2
@@ -126,7 +126,7 @@ postgresql:
 {% if patroni_postgresql_pg_hba |d([], true) |length > 0 %}
   pg_hba:
   {% for client in patroni_postgresql_pg_hba %}
-    - {{ client.type }} {{ client.database }} {{ client.user }} {{ client.address |d(None) }} {{ client.method }} {{ client.options |d(None) }}
+    - {{ client.type }} {{ client.database }} {{ client.user }}{{ ' ' + client.address if client.address is defined else '' }} {{ client.method }}{{ ' ' + client.options if client.options is defined else '' }}
   {% endfor %}
 {% endif %}
 {% if patroni_postgresql_pg_ident |d([], true) |length > 0 %}


### PR DESCRIPTION
  ## Description
  This PR fixes an issue in the Patroni configuration where literal `None' were printed.

  ## Motivation and Context
  When pg_hba entries don't have an `address` or `options` field defined, the Jinja2 template was outputting 'None' as a literal string in the configuration file. This could cause PostgreSQL to fail parsing the pg_hba configuration or interpret 'None' as an actual value rather than omitting the field.

  ## How Has This Been Tested?
  - Verified the generated config.yml has proper formatting without 'None' values

  ## Screenshots (if appropriate):
  N/A

  ## Types of Changes
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

  ## Checklist:
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.